### PR TITLE
Show type info as popup menu along with links to lookup symbol

### DIFF
--- a/Ensime.sublime-settings
+++ b/Ensime.sublime-settings
@@ -2,6 +2,7 @@
   // binding settings
   "ctrl_click_goes_to_definition": true,
   "alt_click_inspects_type_at_point": true,
+  "single_click_inspects_type_at_point": true,
 
   // status settings
   "ensime_statusbar_group": "ensime",

--- a/ensime.py
+++ b/ensime.py
@@ -1348,12 +1348,20 @@ class Notes(EnsimeToolView):
         return "\n".join(lines)
 
 
+class EnsimeSingleClick(EnsimePreciseMouseCommand):
+    def is_applicable(self):
+        return self.env.settings.get("single_click_inspects_type_at_point") and super(EnsimeSingleClick, self).is_applicable()
+
+    def run(self, target):
+        self.v.run_command("ensime_inspect_type_at_point_status", {"target": target})
+
+
 class EnsimeAltClick(EnsimePreciseMouseCommand):
     def is_applicable(self):
         return self.env.settings.get("alt_click_inspects_type_at_point") and super(EnsimeAltClick, self).is_applicable()
 
     def run(self, target):
-        self.v.run_command("ensime_inspect_type_at_point", {"target": target})
+        self.v.run_command("ensime_inspect_type_at_point_tooltip", {"target": target})
 
 
 class EnsimeCtrlClick(EnsimePreciseMouseCommand):
@@ -1440,53 +1448,72 @@ class EnsimeHandleSymbolInfo(EnsimeCommon):
         v.show(region)
 
 
-class EnsimeInspectTypeAtPoint(RunningProjectFileOnly, EnsimeTextCommand, EnsimeHandleSymbolInfo):
+class EnsimeInspectType:
     tuple_regex = re.compile("^Tuple\d+")
 
+    # is_tooltip param is a boolean which determines if either a status_message string
+    # or tooltip is generated
+    def parse_tpe(self, tpe, is_tooltip):
+        if tpe and tpe.name != "<notype>":
+            if tpe.arrow_type:
+                type_info = tpe.result_type
+            else:
+                type_info = tpe
+
+            if EnsimeInspectType.tuple_regex.match(type_info.name):
+                begin, end = '(', ')'
+                res = ""
+            else:
+                begin, end = '[', ']'
+                full_name, name = type_info.full_name, type_info.name
+                if is_tooltip:
+                    res = "<a href={0}>{1}</a>".format(html.escape(full_name), html.escape(name))
+                else:
+                    res = name
+
+            if type_info.type_args:
+                res += begin + ", ".join([self.parse_tpe(t, is_tooltip) for t in type_info.type_args]) + end
+
+            return res
+
+        return None
+
+
+class EnsimeInspectTypeAtPointTooltip(RunningProjectFileOnly, EnsimeTextCommand, EnsimeHandleSymbolInfo, EnsimeInspectType):
     def run(self, edit, target=None):
         pos = int(target or self.v.sel()[0].begin())
         self.rpc.type_at_point(self.v.file_name(), pos, self.handle_reply)
 
     def handle_reply(self, tpe):
-        self.log_client("EnsimeInspectTypeAtPoint.handleReply: " + str(tpe))
-        summary = self.parse_tpe_link(tpe)
-        if summary:
+        self.log_client("EnsimeInspectTypeTooltip.handleReply: " + str(tpe))
+        markup = self.parse_tpe(tpe, is_tooltip=True)
+        if tpe:
             font_size = sublime.load_settings("Preferences.sublime-settings").get("font_size", 14)
             self.w.active_view().show_popup(
-                "<div style=font-size:{0}px>{1}</div>".format(font_size, summary),
-                on_navigate=bind(self.goto_symbol),
+                "<div style=font-size:{0}px>{1}</div>".format(font_size, markup),
+                on_navigate=bind(self.go_to_symbol),
                 max_width=font_size * 80,
                 max_height=font_size * 4
             )
         else:
             self.status_message("Cannot find out type")
 
-    def goto_symbol(self, symbol):
+    def go_to_symbol(self, symbol):
         self.rpc.symbol_by_name(symbol, [], [], self.handle_symbol_info)
 
-    # Going to generate the HTML string to put the links in
-    def parse_tpe_link(self, tpe):
-        if tpe and tpe.name != "<notype>":
-            if tpe.arrow_type:
-                # summary = "method type"
-                type_info = tpe.result_type
-            else:
-                type_info = tpe
 
-            if EnsimeInspectTypeAtPoint.tuple_regex.match(type_info.name):
-                begin_sep, end_sep = "(", ")"
-                markup = ""
-            else:
-                begin_sep, end_sep = "[", "]"
-                full_name, name = html.escape(type_info.full_name), html.escape(type_info.name)
-                markup = "<a href={0}>{1}</a>".format(full_name, name)
+class EnsimeInspectTypeAtPointStatus(RunningProjectFileOnly, EnsimeTextCommand, EnsimeHandleSymbolInfo, EnsimeInspectType):
+    def run(self, edit, target=None):
+        pos = int(target or self.v.sel()[0].begin())
+        self.rpc.type_at_point(self.v.file_name(), pos, self.handle_reply)
 
-            if type_info.type_args:
-                markup += begin_sep + ", ".join([self.parse_tpe_link(t) for t in type_info.type_args]) + end_sep
-
-            return markup
-
-        return None
+    def handle_reply(self, tpe):
+        self.log_client("EnsimeInspectTypeStatus.handleReply: " + str(tpe))
+        msg = self.parse_tpe(tpe, is_tooltip=False)
+        if msg:
+            self.status_message(msg)
+        else:
+            self.status_message("Cannot find out type")
 
 
 class EnsimeGoToDefinition(RunningProjectFileOnly, EnsimeTextCommand, EnsimeHandleSymbolInfo):

--- a/rpc.py
+++ b/rpc.py
@@ -492,6 +492,10 @@ class Rpc(object):
     def symbol_at_point(self, file_name, position):
         pass
 
+    @async_rpc(SymbolInfo.parse)
+    def symbol_by_name(self, symbol, token, t):
+        pass
+
     @async_rpc(SymbolSearchResults.parse_list)
     def import_suggestions(self, file_name, position, type_names, max_results):
         pass


### PR DESCRIPTION
Just some added some Intellij like functionality of the alt-click bringing up a tooltip (Using sublime text 3's fairly limited tooltip API).  Also each separate type in the tooltip becomes a link which can be clicked into to jump to the source.

![screen shot 2015-08-04 at 10 27 42 pm](https://cloud.githubusercontent.com/assets/1167633/9078812/0c71c494-3af8-11e5-9e3b-801585eed6e6.png)

![screen shot 2015-08-04 at 10 25 30 pm](https://cloud.githubusercontent.com/assets/1167633/9078794/eab53a5c-3af7-11e5-90d9-f2ed6927d14f.png)

First image shows what alt-click does on a method, then second picture is what happens if you click on RangePosition.  I don't know any way to style the tooltip that pops up beyond the font size / maximum size of the tooltip (again, the API is fairly limited).
