### PR TITLE
Expand the popup and status type info to include params for arrow types.

### DIFF
--- a/ensime.py
+++ b/ensime.py
@@ -1460,16 +1460,24 @@ class EnsimeInspectType:
             else:
                 type_info = tpe
 
+            type_desc = tpe.name
+
             if EnsimeInspectType.tuple_regex.match(type_info.name):
                 begin, end = '(', ')'
                 res = ""
             else:
                 begin, end = '[', ']'
                 full_name, name = type_info.full_name, type_info.name
+                last_paren = type_desc.rfind(')')
+                type_desc_sans_return = type_desc[0:last_paren+1]
                 if is_tooltip:
                     res = "<a href={0}>{1}</a>".format(html.escape(full_name), html.escape(name))
+                    if type_desc_sans_return:
+                        res = "{0}: {1}".format(html.escape(type_desc_sans_return), res)
                 else:
                     res = name
+                    if type_desc_sans_return:
+                        res = "{0}: {1}".format(type_desc_sans_return, res)
 
             if type_info.type_args:
                 res += begin + ", ".join([self.parse_tpe(t, is_tooltip) for t in type_info.type_args]) + end


### PR DESCRIPTION
Note that this an improvement on the information available previously, but there
is still room for more. In particular, in the tooltip, only the return type is
hot-linked right now, ensime seems not to give back rich param information at
present so that will need to be added. Made the decision that this is enough
of an improvement for its own PR though.

Simple val types are unaffected.

Examples:

![tooltip1](https://cloud.githubusercontent.com/assets/56453/9429331/144cb326-4981-11e5-904a-6815585745bf.png)

![tooltip2](https://cloud.githubusercontent.com/assets/56453/9429334/19b8a78e-4981-11e5-9982-ff5e12b0212b.png)

![tooltip3](https://cloud.githubusercontent.com/assets/56453/9429335/1f3ae956-4981-11e5-96c4-8f8c5d56a54f.png)
