### PR TITLE
Don't join curried parameter lists with ,

### DIFF
--- a/ensime.py
+++ b/ensime.py
@@ -1175,7 +1175,7 @@ class Completer(EnsimeEventListener):
         section_param_strs = [[param[1] for param in params] for params in sections]
         section_strs = ["(" + ", ".join(tpes) + ")" for tpes in
                         section_param_strs]
-        return ", ".join(section_strs) + ": " + sig.result
+        return "".join(section_strs) + ": " + sig.result
 
     def _signature_snippet(self, sig):
         """Given a ensime CompletionSignature structure, returns a Sublime Text
@@ -1191,7 +1191,7 @@ class Completer(EnsimeEventListener):
                 param_snippets.append("${%s:%s:%s}" % (i, name, tpe))
                 i += 1
             section_snippets.append("(" + ", ".join(param_snippets) + ")")
-        return ", ".join(section_snippets)
+        return "".join(section_snippets)
 
     def _completion_response(self, ensime_completions):
         """Transform list of completions from ensime API to a the structure


### PR DESCRIPTION
Previously, curried parameter lists were joined with , in both the completions
popup and the inserted code, so you would get stuff like this:

`eventually(fun:<byname>[T]), (config:PatienceConfig)`

requiring the user to delete that , between param lists to get correct code.
after this change you get the more useful:

`eventually(fun:<byname>[T])(config:PatienceConfig)`