### PR TITLE
Typecheck on goto

### DIFF
--- a/Context.sublime-menu
+++ b/Context.sublime-menu
@@ -33,6 +33,7 @@
               { "caption": "Inline Local", "command": "ensime_inline_local" },
               { "caption": "Extract Local", "command": "ensime_extract_local"},
               { "caption": "Extract Method", "command": "ensime_extract_method"},
+              { "caption": "Full Type Check", "command": "ensime_typecheck_full"},
               { "caption": "Build", "command": "ensime_build" }
             ]
           },

--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -24,6 +24,10 @@
     "command": "ensime_show_session"
   },
   {
+    "caption": "Ensime: Full Type Check",
+    "command": "ensime_typecheck_full"
+  },
+  {
     "caption": "Ensime: Build",
     "command": "ensime_build"
   },

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -36,6 +36,7 @@
                       { "caption": "Inline Local", "command": "ensime_inline_local"},
                       { "caption": "Extract Local", "command": "ensime_extract_local"},
                       { "caption": "Extract Method", "command": "ensime_extract_method"},
+                      { "caption": "Full Type Check", "command": "ensime_typecheck_full"},
                       { "caption": "Build", "command": "ensime_build" }
                     ]
                   },

--- a/ensime.py
+++ b/ensime.py
@@ -1177,7 +1177,7 @@ class Completer(EnsimeEventListener):
         section_param_strs = [[param[1] for param in params] for params in sections]
         section_strs = ["(" + ", ".join(tpes) + ")" for tpes in
                         section_param_strs]
-        return ", ".join(section_strs) + ": " + sig.result
+        return "".join(section_strs) + ": " + sig.result
 
     def _signature_snippet(self, sig):
         """Given a ensime CompletionSignature structure, returns a Sublime Text
@@ -1193,7 +1193,7 @@ class Completer(EnsimeEventListener):
                 param_snippets.append("${%s:%s:%s}" % (i, name, tpe))
                 i += 1
             section_snippets.append("(" + ", ".join(param_snippets) + ")")
-        return ", ".join(section_snippets)
+        return "".join(section_snippets)
 
     def _completion_response(self, ensime_completions):
         """Transform list of completions from ensime API to a the structure

--- a/ensime.py
+++ b/ensime.py
@@ -683,7 +683,7 @@ class Client(ClientListener, EnsimeCommon):
 
     @call_back_into_ui_thread
     def message_full_typecheck_finished(self, msg_id, payload):
-        self.status_message("Full type check completed")
+        pass
 
     @call_back_into_ui_thread
     def message_background_message(self, msg_id, payload):
@@ -1558,7 +1558,6 @@ class EnsimeTypecheckFull(EnsimeTextCommand):
 
     def typecheck_all_finished(self, msg_id):
         self.status_message("Full type check completed")
-
 
 
 # common superclass to make refactoring definitions a little less boiler-platey

--- a/rpc.py
+++ b/rpc.py
@@ -477,6 +477,10 @@ class Rpc(object):
         pass
 
     @async_rpc()
+    def typecheck_all(self):
+        pass
+
+    @async_rpc()
     def patch_source(self, file_name, edits):
         pass
 


### PR DESCRIPTION
Fixed up the type sigs for auto completion (no commas between parameter lists) then added a "try harder" feature to goto definition, which if the first goto fails, issues a full typecheck request and then tries it again. If that one fails, it then falls back to the best guess goto definition supplied by sublime.