### PR TITLE
Even better type tooltips

### DIFF
--- a/ensime.py
+++ b/ensime.py
@@ -1472,13 +1472,31 @@ class EnsimeHandleSymbolInfo(EnsimeCommon):
 class EnsimeInspectType:
     tuple_regex = re.compile("^Tuple\d+")
 
+    def format_param(self, param, begin, end, is_tooltip):
+        res = "{0}: <a href={1}>{2}</a>".format(
+            html.escape(param.param_name),
+            html.escape(param.param_type.full_name),
+            html.escape(param.param_type.name)
+        )
+        if param.param_type.type_args:
+            res += begin + ", ".join([self.parse_tpe(t, is_tooltip) for t in param.param_type.type_args]) + end
+        return res
+
+    def format_param_list(self, param_section, begin, end, is_tooltip):
+        return "({0}{1})".format(
+            "implicit " if param_section.is_implicit else "",
+            ", ".join([self.format_param(p, begin, end, is_tooltip) for p in param_section.params])
+        )
+
     # is_tooltip param is a boolean which determines if either a status_message string
     # or tooltip is generated
     def parse_tpe(self, tpe, is_tooltip):
         if tpe and tpe.name != "<notype>":
             if tpe.arrow_type:
+                param_sections = tpe.param_sections
                 type_info = tpe.result_type
             else:
+                param_sections = []
                 type_info = tpe
 
             type_desc = tpe.name
@@ -1489,14 +1507,15 @@ class EnsimeInspectType:
             else:
                 begin, end = '[', ']'
                 full_name, name = type_info.full_name, type_info.name
-                last_paren = type_desc.rfind(')')
-                type_desc_sans_return = type_desc[0:last_paren+1]
                 if is_tooltip:
+                    param_section_list = "".join([self.format_param_list(ps, begin, end, is_tooltip) for ps in param_sections])
                     res = "<a href={0}>{1}</a>".format(html.escape(full_name), html.escape(name))
-                    if type_desc_sans_return:
-                        res = "{0}: {1}".format(html.escape(type_desc_sans_return), res)
+                    if param_section_list:
+                        res = "{0}: {1}".format(param_section_list, res)
                 else:
                     res = name
+                    last_paren = type_desc.rfind(')')
+                    type_desc_sans_return = type_desc[0:last_paren+1]
                     if type_desc_sans_return:
                         res = "{0}: {1}".format(type_desc_sans_return, res)
 

--- a/ensime.py
+++ b/ensime.py
@@ -1508,10 +1508,12 @@ class EnsimeInspectType:
                 begin, end = '[', ']'
                 full_name, name = type_info.full_name, type_info.name
                 if is_tooltip:
+                    # grab any type args from the description first
+                    type_args = "" if type_desc[0] != '[' else html.escape(type_desc[0:type_desc.find('](') + 1])
                     param_section_list = "".join([self.format_param_list(ps, begin, end, is_tooltip) for ps in param_sections])
                     res = "<a href={0}>{1}</a>".format(html.escape(full_name), html.escape(name))
                     if param_section_list:
-                        res = "{0}: {1}".format(param_section_list, res)
+                        res = "{0}{1}: {2}".format(type_args, param_section_list, res)
                 else:
                     res = name
                     last_paren = type_desc.rfind(')')

--- a/rpc.py
+++ b/rpc.py
@@ -193,12 +193,17 @@ class Member(ActiveRecord):
 class ParamSectionInfo(ActiveRecord):
     def populate(self, m):
         self.is_implicit = bool(m[":is-implicit"]) if ":is-implicit" in m else False
-        self.params = Param.parse_list(m[":params"]) if ":params" in m else []
+        if ":params" in m and m[":params"]:
+            keyed_params = [{':param-name': p[0], ':param-type': p[1]} for p in m[":params"]]
+            self.params = [Param(kp) for kp in keyed_params]
+        else:
+            self.params = []
 
 
-class Param(ActiveRecord):
-    def populate(self, m):
-        pass
+class Param:
+    def __init__(self, m):
+        self.param_name = m[":param-name"]
+        self.param_type = TypeInfo.parse(m[":param-type"])
 
 
 class DebugEvent(ActiveRecord):


### PR DESCRIPTION
Bit of a hack, but it seems to work. Since I can't find the generic type parameters in the returned type info package, for those I simply chop off the beginning of the description string if the string starts with `[` up until the point where I see `)[` - it's super cheesy, but that should get the generic parameters. After that, the rest of the type info is built up correctly and recursively with hot links back to the original types wherever possible. Status bar type info is unaffected by this PR.

Long term I would like to get the generic parameters back as part of the payload from Ensime server, but before that I think moving to Json would be wise anyway since there are a number of dodgy hacks to get the returned sexp to work with these tooltips already.