### PR TITLE
Use window folder for ensime detection, when available

### DIFF
--- a/ensime.py
+++ b/ensime.py
@@ -1008,7 +1008,7 @@ class Daemon(EnsimeEventListener):
     def on_post_save(self):
         if self.is_running() and self.in_project():
             self.rpc.typecheck_file(SourceFileInfo(self.v.file_name()))
-        if same_paths(self.v.file_name(), self.env.session_file):
+        if self.env and same_paths(self.v.file_name(), self.env.session_file):
             self.env.load_session()
             self.redraw_all_breakpoints()
 

--- a/env.py
+++ b/env.py
@@ -14,22 +14,23 @@ ensime_envs = {}
 
 def for_window(window):
     if window:
-        if window.id() in ensime_envs:
-            return ensime_envs[window.id()]
+        window_key = (window.folders() or [window.id()])[0]
+        if window_key in ensime_envs:
+            return ensime_envs[window_key]
         envLock.acquire()
         try:
-            if not (window.id() in ensime_envs):
+            if not (window_key in ensime_envs):
                 # protection against reentrant EnsimeEnvironment §s
-                ensime_envs[window.id()] = None
+                ensime_envs[window_key] = None
                 try:
-                    ensime_envs[window.id()] = EnsimeEnvironment(window)
-                    print("Created ensime environment for ", window)
+                    ensime_envs[window_key] = EnsimeEnvironment(window)
+                    print("Created ensime environment for ", window_key)
                 except:
-                    print("No ensime environment for ", window)
+                    print("No ensime environment for ", window_key)
             else:
-                print("Found existing ensime environment for ", window)
+                print("Found existing ensime environment for ", window_key)
 
-            return ensime_envs[window.id()]
+            return ensime_envs[window_key]
         finally:
             envLock.release()
     return None


### PR DESCRIPTION
My previous "fix" meant that new windows opened on an ensime project
did not initialize correctly (the ensime detection kicked in before
the folder was set for the window, by that stage the caching had
decided that the window had no ensime and would never try and create
one). Now it uses the folder for the window, so when you switch to
the window, the folder path is used as a key and even if it detected
no ensime env, that will be under another key and not interfere with
this one being detected.