### PR TITLE
Debug step out and useful launch defaults

### DIFF
--- a/dotsession.py
+++ b/dotsession.py
@@ -121,7 +121,9 @@ def save(env, data):
                    "current_launch_config": data.launch_key}
         if not session["launch_configs"]:
             # create a dummy launch config, so that the user has easier time filling in the config
-            session["launch_configs"] = [{"name": "", "main_class": "", "args": "", "remote_address": ""}]
+            session["launch_configs"] = [{"name": "Remote Debug", "main_class": "",
+                                          "args": "", "remote_address": "localhost:5005"}]
+            session["current_launch_config"] = "Remote Debug"
         contents = json.dumps(session, sort_keys=True, indent=2)
         with open(file_name, "w") as f:
             f.write(contents)

--- a/ensime.py
+++ b/ensime.py
@@ -1842,6 +1842,11 @@ class EnsimeStepOver(FocusedOnly, EnsimeWindowCommand):
         self.env.debugger.step_over()
 
 
+class EnsimeStepOut(FocusedOnly, EnsimeWindowCommand):
+    def run(self):
+        self.env.debugger.step_out()
+
+
 class EnsimeContinueDebugger(FocusedOnly, EnsimeWindowCommand):
     def run(self):
         self.env.debugger.continue_()
@@ -2047,6 +2052,9 @@ class Debugger(EnsimeCommon):
 
     def continue_(self):
         self.rpc.debug_continue(self.env.focus.thread_id)
+
+    def step_out(self):
+        self.rpc.debug_next(self.env.focus.thread_id)
 
 
 class Focus(object):


### PR DESCRIPTION
Add a debug step out RPC and command,
also update default .session file template to give a useful
remote debug attach by default if no other run target is specified.