### PR TITLE
Add browse scaladoc at current location functionality.

### DIFF
--- a/Context.sublime-menu
+++ b/Context.sublime-menu
@@ -27,6 +27,7 @@
             [
               { "caption": "Show notes", "command": "ensime_show_notes" },
               { "caption": "Inspect type at point", "command": "ensime_inspect_type_at_point" },
+              { "caption": "Browse Scaladoc at point", "command": "ensime_browse_scaladoc_at_point" },
               { "caption": "Go to definition", "command": "ensime_go_to_definition" },
               { "caption": "Add import", "command": "ensime_add_import" },
               { "caption": "Organize imports", "command": "ensime_organize_imports" },

--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -60,6 +60,10 @@
     "command": "ensime_inspect_type_at_point"
   },
   {
+    "caption": "Ensime: Browse Scaladoc at Point",
+    "command": "ensime_browse_scaladoc_at_point"
+  },
+  {
     "caption": "Ensime: Go to Definition",
     "command": "ensime_go_to_definition"
   },

--- a/rpc.py
+++ b/rpc.py
@@ -509,6 +509,14 @@ class Rpc(object):
     def symbol_by_name(self, symbol, token, t):
         pass
 
+    @async_rpc()
+    def doc_uri_at_point(self, file_name, position):
+        pass
+
+    @async_rpc()
+    def doc_uri_for_symbol(self, symbol, token, t):
+        pass
+
     @async_rpc(SymbolSearchResults.parse_list)
     def import_suggestions(self, file_name, position, type_names, max_results):
         pass


### PR DESCRIPTION
Enables the browse scaladoc at cursor location. Right now opens a new tab in an existing browser - might make this customizable in time, although ideally I would like to make it pop-up a window if the user desires that. Both of these are nice-to-haves though and this is preferable to having no browse support at all...