### PR TITLE
Ensime server wasn't killed in windows, os.kill raises an erro this i…

### DIFF
--- a/ensimesublime/launcher.py
+++ b/ensimesublime/launcher.py
@@ -24,7 +24,10 @@ class EnsimeProcess(object):
     def stop(self):
         if self.process is None:
             return
-        os.kill(self.process.pid, signal.SIGTERM)
+        try:
+            os.kill(self.process.pid, signal.SIGTERM)
+        except PermissionError:
+            subprocess.Popen("taskkill /F /T /PID %i" % self.process.pid , shell=True)
         self.__cleanup()
         self.__stopped_manually = True
 


### PR DESCRIPTION
Ensime server wasn't killed in windows, os.kill raises an error this is a workaround, see https://forum.sublimetext.com/t/can-not-kill-windows-shell-process-access-denied/13392