### PR TITLE
Updates: toggle errors, changed completion sig

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -1,5 +1,5 @@
 [
   { "keys": ["ctrl+alt+i"], "command": "ensime_add_import" },
-  { "keys": ["ctrl+alt+e"], "command": "ensime_show_errors" },
+  { "keys": ["ctrl+alt+e"], "command": "ensime_toggle_errors" },
   { "keys": ["ctrl+alt+o"], "command": "ensime_organise_imports" }
 ]

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -1,5 +1,5 @@
 [
   { "keys": ["alt+i"], "command": "ensime_add_import" },
-  { "keys": ["super+alt+e"], "command": "ensime_show_errors" },
+  { "keys": ["super+alt+e"], "command": "ensime_toggle_errors" },
   { "keys": ["super+alt+o"], "command": "ensime_organise_imports" }
 ]

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -1,5 +1,5 @@
 [
   { "keys": ["alt+i"], "command": "ensime_add_import" },
-  { "keys": ["ctrl+alt+e"], "command": "ensime_show_errors" },
+  { "keys": ["ctrl+alt+e"], "command": "ensime_toggle_errors" },
   { "keys": ["ctrl+alt+o"], "command": "ensime_organise_imports" }
 ]

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -10,7 +10,7 @@
                   { "caption": "Startup", "command": "ensime_startup" },
                   { "caption": "Shutdown", "command": "ensime_shutdown" },
                   { "caption": "-", "id": "development" },
-                  { "caption": "Show errors and warnings", "command": "ensime_show_errors" }
+                  { "caption": "Toggle errors and warnings", "command": "ensime_toggle_errors" }
                 ]
             }
         ]

--- a/commands.py
+++ b/commands.py
@@ -88,7 +88,7 @@ class EnsimeEventListener(sublime_plugin.EventListener):
             else:
                 env.editor.ignore_prefix = None
 
-            if (env.editor.current_prefix and prefix == env.editor.current_prefix):
+            if (env.editor.current_prefix is not None and prefix == env.editor.current_prefix):
                 env.editor.current_prefix = None
                 if view.is_popup_visible():
                     view.hide_popup()

--- a/commands.py
+++ b/commands.py
@@ -45,7 +45,7 @@ class EnsimeShutdown(EnsimeWindowCommand):
         self.env.shutdown()
 
 
-class EnsimeShowErrors(EnsimeWindowCommand):
+class EnsimeToggleErrors(EnsimeWindowCommand):
     def is_enabled(self):
         return bool(self.env and
                     self.env.is_connected() and
@@ -53,8 +53,11 @@ class EnsimeShowErrors(EnsimeWindowCommand):
                     self.env.client.analyzer_ready)
 
     def run(self):
-        self.env.editor.show_errors = True
-        self.env.editor.redraw_all_highlights()
+        if self.env.editor.show_errors:
+            self.env.editor.hide_phantoms()
+        else:
+            self.env.editor.show_errors = True
+            self.env.editor.redraw_all_highlights()
 
 
 class EnsimeEventListener(sublime_plugin.EventListener):

--- a/ensimesublime/launcher.py
+++ b/ensimesublime/launcher.py
@@ -24,7 +24,7 @@ class EnsimeProcess(object):
     def stop(self):
         if self.process is None:
             return
-        os.kill(self.process.pid, signal.SIGTERM)
+        self.process.terminate()
         self.__cleanup()
         self.__stopped_manually = True
 

--- a/ensimesublime/launcher.py
+++ b/ensimesublime/launcher.py
@@ -24,7 +24,7 @@ class EnsimeProcess(object):
     def stop(self):
         if self.process is None:
             return
-        self.process.terminate()
+        os.kill(self.process.pid, signal.SIGTERM)
         self.__cleanup()
         self.__stopped_manually = True
 

--- a/ensimesublime/protocol.py
+++ b/ensimesublime/protocol.py
@@ -205,8 +205,9 @@ consequently the context menu commands may take longer to get enabled. You may c
     def handle_completion_info_list(self, call_id, payload):
         """Handler for a completion response."""
         prefix = payload.get("prefix")
-        if (self.env.editor.current_prefix and
+        if (self.env.editor.current_prefix is not None and
                 self.env.editor.current_prefix == prefix):
+            self.env.logger.debug('handle_completion_info_list: in async')
 
             def _hack(prefix):
                 if (sublime.active_window().active_view().is_auto_complete_visible() and
@@ -222,7 +223,7 @@ consequently the context menu commands may take longer to get enabled. You may c
 
         else:
             self.env.editor.current_prefix = payload.get("prefix")
-            self.env.logger.debug('handle_completion_info_list: in')
+            self.env.logger.debug('handle_completion_info_list: in sync')
             # filter out completions without `typeInfo` field to avoid server bug. See #324
             completions = [c for c in payload["completions"] if "typeInfo" in c]
             self.env.editor.suggestions = [completion_to_suggest(c) for c in completions]


### PR DESCRIPTION
Earlier it was used to only show errors and warnings, and we had to move the mouse to 'x' to hide them.
Same key binding should be used to hide them too.